### PR TITLE
Fix V575 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/acllib.c
+++ b/src/acllib.c
@@ -810,10 +810,12 @@ void loadSound(const char *fileName,ACL_Sound *pSound)
 	int len = strlen(fileName)*sizeof(char);
 	len +=64;
 	cmdStr = (char*)malloc(len);
-	sprintf(cmdStr,"open \"%s\" type mpegvideo alias S%d",fileName,g_soundID);
-	*pSound = g_soundID;
-	++g_soundID;
-	mciSendStringA(cmdStr,NULL,0,NULL);
+	if (cmdStr != NULL) {
+		sprintf(cmdStr,"open \"%s\" type mpegvideo alias S%d",fileName,g_soundID);
+		*pSound = g_soundID;
+		++g_soundID;
+		mciSendStringA(cmdStr,NULL,0,NULL);
+	}
 	free(cmdStr);
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
V575 The potential null pointer is passed into 'sprintf' function. Inspect the first argument. acllib.c 813